### PR TITLE
Add Language Parameter and Twig Debug Option

### DIFF
--- a/configuration.example.full.json
+++ b/configuration.example.full.json
@@ -83,6 +83,7 @@
 					"passage_boundary": "sentence|paragraph|zone"
 				},
 				"allowParameters": "q,offset,limit,...",
+				"languages": "en-en,de-de,...",
 				"allowAttributes": {
 					"set_filter": "ATTR1,ATTR2,...",
 					"set_filter_range": "ATTR1,ATTR2,...",
@@ -113,6 +114,6 @@
 		"templatesPath": "../views"
 	},
 	"twig": {
-		"nothing": "yet"
+		"debug": true
 	}
 }

--- a/views/description.xml
+++ b/views/description.xml
@@ -4,6 +4,8 @@
 	<Description>Open up your indexes for syndication and aggregation</Description>
 	<Tags>example web</Tags>
 	<Contact>admin@example.com</Contact>
+	<Language>en-en</Language>
+	<Language>de-de</Language>
 	<InputEncoding>UTF-8</InputEncoding>
 	<OutputEncoding>UTF-8</OutputEncoding>
 	<Url type="application/opensearchdescription+xml" rel="self" template="http://{{ host }}{{ path }}" />


### PR DESCRIPTION
- make it possible to set debug: true in config for twig to enbale template debugging
- add lang parameter to query parameters according to the opensearch documentation: https://github.com/dewitt/opensearch/blob/master/opensearch-1-1-draft-6.md#opensearch-url-template-syntax
- add language tag to description document accordind to the opensearch documentation: https://github.com/dewitt/opensearch/blob/master/opensearch-1-1-draft-6.md#opensearch-description-document