### PR TITLE
Fix placement of slash in html link.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "require": {
         "slim/slim": "2.*",
         "slim/views": "0.1.*",
-        "twig/twig": "1.*",
+        "twig/twig": "1.44.*",
         "neutron/sphinxsearch-api": "2.0.*"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -232,16 +232,16 @@
         },
         {
             "name": "twig/twig",
-            "version": "v1.38.0",
+            "version": "v1.44.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/twigphp/Twig.git",
-                "reference": "754b8dfc0026585eb8498ec4bf5ff240b6b34db7"
+                "reference": "b1f009c449e435a0384814e67205d9190a4d050e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/twigphp/Twig/zipball/754b8dfc0026585eb8498ec4bf5ff240b6b34db7",
-                "reference": "754b8dfc0026585eb8498ec4bf5ff240b6b34db7",
+                "url": "https://api.github.com/repos/twigphp/Twig/zipball/b1f009c449e435a0384814e67205d9190a4d050e",
+                "reference": "b1f009c449e435a0384814e67205d9190a4d050e",
                 "shasum": ""
             },
             "require": {
@@ -296,7 +296,7 @@
             ],
             "support": {
                 "issues": "https://github.com/twigphp/Twig/issues",
-                "source": "https://github.com/twigphp/Twig/tree/v1.38.0"
+                "source": "https://github.com/twigphp/Twig/tree/v1.44.8."
             },
             "time": "2019-03-12T12:42:04+00:00"
         }

--- a/views/index.html
+++ b/views/index.html
@@ -2,7 +2,11 @@
 <html>
 	<head>
 		{% for index in indexes %}
-		<link rel="search" type="application/opensearchdescription+xml" title="{{ index.description }}" href="{{ index.path }}/">
+		<link
+            rel="search"
+            type="application/opensearchdescription+xml"
+            title="{{ index.description }}"
+            href="{{ index.path }}" />
 		{% endfor %}
 	</head>
 	<body>


### PR DESCRIPTION
If I got it right, the `<link>` element is a self-closing element that should look like this: `<link ... />` (with a forward slash in front of the closing angled bracket). Currently there is a forward slash, but it's inside the `href` attribute. This commit/PR moves it out of the attribute. Hopefully it's really just a typo and the slash is not actually needed inside the attribute...